### PR TITLE
Fix blue-green frontend port conflict with Grafana

### DIFF
--- a/deploy-blue-green.sh
+++ b/deploy-blue-green.sh
@@ -10,8 +10,10 @@ COMPOSE_FILE="docker-compose.prod.yml"
 DEPLOY_DIR="/opt/stayafrica"
 BLUE_PORT=8001
 GREEN_PORT=8002
-BLUE_FE_PORT=3001
-GREEN_FE_PORT=3002
+# Note: 3001 is reserved for Grafana (see docker-compose.prod.yml), so the
+# blue/green frontend ports must avoid it.
+BLUE_FE_PORT=3011
+GREEN_FE_PORT=3012
 NGINX_CONF="./nginx/upstreams.conf"
 
 LOCK_FILE="/tmp/stayafrica_deploy.lock"


### PR DESCRIPTION
## Summary
- `deploy-blue-green.sh` hardcoded `BLUE_FE_PORT=3001`, which is the same host port Grafana binds to in `docker-compose.prod.yml` (`ports: "3001:3000"`).
- When the blue frontend container (`stayafrica_frontend_blue`) is left running from a prior blue-green deploy and the full prod stack (including Grafana) is brought up, `docker compose up` fails with `Bind for 0.0.0.0:3001 failed: port is already allocated` — this is exactly what happened on the production host.
- Moved the blue/green frontend ports to `3011`/`3012`, which don't collide with any other port used in the compose files or docs, and added a comment noting why 3001 is off-limits.

## Test plan
- [ ] `bash -n deploy-blue-green.sh` (syntax check, passed locally)
- [ ] Run `./deploy-blue-green.sh deploy` on staging/prod and confirm the full stack (including Grafana on 3001) comes up without port conflicts


---
_Generated by [Claude Code](https://claude.ai/code/session_014vp4QnGENvtP5vCnjtxP9Y)_